### PR TITLE
Add Honeybadger as gemspec dependency

### DIFF
--- a/command_ruby.gemspec
+++ b/command_ruby.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'zeitwerk', '~> 2.1'
   spec.add_runtime_dependency 'activesupport', '>= 5.0'
+  spec.add_runtime_dependency 'honeybadger', '>= 4.12'
 
   spec.add_development_dependency 'pry', '~>0.10'
   spec.add_development_dependency 'bundler', '>= 1.13'

--- a/lib/commands/logging/logger.rb
+++ b/lib/commands/logging/logger.rb
@@ -1,3 +1,5 @@
+require 'honeybadger'
+
 module Commands
   module Logging
     module Logger


### PR DESCRIPTION
Added Honeybadger as an exlicit dependency. It is used in the logging.

Note: This could be refactored to make it a optional dependency, checking for its existence before calling Honeybadger.
